### PR TITLE
Fix search path for templates

### DIFF
--- a/conventional/commands/template.py
+++ b/conventional/commands/template.py
@@ -206,7 +206,7 @@ async def main(
         logger.debug(f"Creating package loader for: {package}")
         loaders.append(jinja2.PackageLoader(package))
 
-    for directory in config["template"]["directory"].get(confuse.Sequence(Filename())):
+    for directory in config["template"]["directory"].get(confuse.StrSeq(split=False)):
         logger.debug(f"Creating file-system loader for: {directory}")
         loaders.append(jinja2.FileSystemLoader(directory))
 


### PR DESCRIPTION
When using a custom config file (via ``--config-file`), the config file name is included in the directory path passed to the template loader.

For example, given the following config:
```yaml
template:
  # `template.package` and `template.directory` can be use to list the Python
  # packages and / or directories to search for templates. Can either be a single
  # item or an array of items.
  directory: [.conventional/templates]

  # The name of the template to load
  name: changelog.md

  # If `True`, unparsed commits will be included when rendering the template.
  include-unparsed: false

  # Configuration specific to the template defined by `template.package` + `template.name`
  # (see https://jinja.palletsprojects.com/en/2.11.x/api/#jinja2.PackageLoader) in this
  # case the configuration is for the `changelog.md` template.
  config:
    # Mapping of types (parsed from git commits) to the headings to use when listing them
    # in the changelog. If a type is missing from this list, commits using that type will
    # not be added to the changelog.
    type-headings:
      feat: Features
      fix: Fixes

```

by calling:

```shell
conventional --config-file conventional.yaml template
```

`conventional` will look into `<CWD>/conventional.yaml/.conventional/templates`, when it should look into `<CWD>/.conventional/templates` instead
